### PR TITLE
Added support for new major version of paknahad/jsonapi-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "paknahad/jsonapi-bundle": "^1.1 | dev-master",
+        "paknahad/jsonapi-bundle": "^2.0 | dev-master",
         "andreas-glaser/doctrine-rql": "^0.2"
     },
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "paknahad/jsonapi-bundle": "^2.0 | dev-master",
+        "paknahad/jsonapi-bundle": "^2.0 | ^1.1 | dev-master",
         "andreas-glaser/doctrine-rql": "^0.2"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
The RQL Finder bundle is compatible with the new version of paknahad/jsonapi-bundle, so either ^1.1 or ^2.0 is required.