### PR TITLE
Support multiple PHP versions (^7.4 and ^8.0)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^7.4",
+        "php": "^7.4|^8.0",
         "paknahad/jsonapi-bundle": "^5.0",
         "andreas-glaser/doctrine-rql": "^0.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,13 @@
 {
     "description": "The jsonapi-bundle-rql-finder offers an RQL filter syntax for the paknahad/jsonapi-bundle bundle.",
-    "name": "mnugter/jsonapi-rql-finder-bundle",
+    "name": "krilo89/jsonapi-rql-finder-bundle",
     "type": "symfony-bundle",
     "license": "MIT",
     "keywords": ["json-api", "symfony", "php", "RESTful"],
     "authors": [
         {
-            "name": "Michiel Nugter",
-            "email": "michiel@synetic.nl"
+            "name": "Jordy Vleugel",
+            "email": "jordy@synetic.nl"
         }
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^7.4",
         "paknahad/jsonapi-bundle": "^5.0",
         "andreas-glaser/doctrine-rql": "^0.4"
     },


### PR DESCRIPTION
This module is literally a bridge for: andreas-glaser/doctrine-rql and paknahad/jsonapi-bundle which both have support for PHP 7.4, so it's better to support both 7.4 and 8.0.